### PR TITLE
Use American English for "modeling"

### DIFF
--- a/views/index.dt
+++ b/views/index.dt
@@ -6,7 +6,7 @@ append head
 append content
     header
         h1 The D Programming Language
-        p Modern convenience. Modelling power. Native efficiency.
+        p Modern convenience. Modeling power. Native efficiency.
     .code-sample
     p
         | D is a language with C-like syntax and static typing.


### PR DESCRIPTION
dlang.org generally uses American English so might as well keep it consistent.
